### PR TITLE
Fix for background images not showing on ios devices

### DIFF
--- a/css/stylish-portfolio.css
+++ b/css/stylish-portfolio.css
@@ -123,7 +123,6 @@ body {
   background-image: url(../img/washington.jpg);
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-size: cover; 
   -webkit-background-size: cover;
   -moz-background-size: cover;
@@ -179,7 +178,6 @@ i.service-icon:hover {
   background-image: url(../img/datacenter.jpg);
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-size: cover; 
   -webkit-background-size: cover;
   -moz-background-size: cover;
@@ -191,7 +189,6 @@ i.service-icon:hover {
   background-image: url(../img/bahrain.jpg);
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-size: cover;
 }
 
@@ -199,7 +196,6 @@ i.service-icon:hover {
   background-image: url(../img/mexico.jpg);
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-size: cover;
 }
 
@@ -207,7 +203,6 @@ i.service-icon:hover {
   background-image: url(../img/vienna.jpg);
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-size: cover;
 }
 
@@ -215,7 +210,6 @@ i.service-icon:hover {
   background-image: url(../img/paris.jpg);
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-size: cover;
 }
 
@@ -223,7 +217,6 @@ i.service-icon:hover {
   background-image: url(../img/arab.jpg);
   background-position: center;
   background-repeat: no-repeat;
-  background-attachment: fixed;
   background-size: cover;
 }
 /* Portfolio */

--- a/css/stylish-portfolio.css
+++ b/css/stylish-portfolio.css
@@ -121,7 +121,9 @@ body {
   width: 100%;
   position: relative;
   background-image: url(../img/washington.jpg);
-  background-position: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   background-size: cover; 
   -webkit-background-size: cover;
   -moz-background-size: cover;
@@ -175,7 +177,9 @@ i.service-icon:hover {
   height: 400px;
   width: 100%;
   background-image: url(../img/datacenter.jpg);
-  background-position: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   background-size: cover; 
   -webkit-background-size: cover;
   -moz-background-size: cover;
@@ -185,31 +189,41 @@ i.service-icon:hover {
 
 .callout.bahrain {
   background-image: url(../img/bahrain.jpg);
-  background-position: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   background-size: cover;
 }
 
 .callout.mexico {
   background-image: url(../img/mexico.jpg);
-  background-position: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   background-size: cover;
 }
 
 .callout.vienna {
   background-image: url(../img/vienna.jpg);
-  background-position: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   background-size: cover;
 }
 
 .callout.paris {
   background-image: url(../img/paris.jpg);
-  background-position: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   background-size: cover;
 }
 
 .callout.arab {
   background-image: url(../img/arab.jpg);
-  background-position: fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   background-size: cover;
 }
 /* Portfolio */

--- a/css/stylish-portfolio.css
+++ b/css/stylish-portfolio.css
@@ -120,7 +120,9 @@ body {
   height: 100%;
   width: 100%;
   position: relative;
-  background: url(../img/washington.jpg) no-repeat center center fixed; 
+  background-image: url(../img/washington.jpg);
+  background-position: fixed;
+  background-size: cover; 
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;
@@ -172,7 +174,9 @@ i.service-icon:hover {
   display: table;
   height: 400px;
   width: 100%;
-  background: url(../img/datacenter.jpg) no-repeat center center fixed; 
+  background-image: url(../img/datacenter.jpg);
+  background-position: fixed;
+  background-size: cover; 
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;
@@ -180,23 +184,33 @@ i.service-icon:hover {
 }
 
 .callout.bahrain {
-  background: url(../img/bahrain.jpg) no-repeat center center fixed;
+  background-image: url(../img/bahrain.jpg);
+  background-position: fixed;
+  background-size: cover;
 }
 
 .callout.mexico {
-  background: url(../img/mexico.jpg) no-repeat center center fixed;
+  background-image: url(../img/mexico.jpg);
+  background-position: fixed;
+  background-size: cover;
 }
 
 .callout.vienna {
-  background: url(../img/vienna.jpg) no-repeat center center fixed;
+  background-image: url(../img/vienna.jpg);
+  background-position: fixed;
+  background-size: cover;
 }
 
 .callout.paris {
-  background: url(../img/paris.jpg) no-repeat center center fixed;
+  background-image: url(../img/paris.jpg);
+  background-position: fixed;
+  background-size: cover;
 }
 
 .callout.arab {
-  background: url(../img/arab.jpg) no-repeat center center fixed;
+  background-image: url(../img/arab.jpg);
+  background-position: fixed;
+  background-size: cover;
 }
 /* Portfolio */
 


### PR DESCRIPTION
The css rules for background images were set with the shorthand method that does not play good with ios devices. After properly settings the background images, i've encoutered a new bug, where the images would show but they were so much stretched i could on see pixels from the image, because of how ios handles background-attachment: fixed rule, it account for the height of the whole page.. I have deleted the rule for fixed attachment, and now it works perfectly. (tested on iphone 6 - iphone X).